### PR TITLE
Add experimental callOperator switch to example app

### DIFF
--- a/example/app.nim
+++ b/example/app.nim
@@ -2,6 +2,8 @@ import dom, jsconsole, jsffi, strutils, sequtils, sugar
 import react
 from react/reactdom import ul, li, input, `div`
 
+{.experimental: "callOperator".}
+
 type
   Country = ref object of RootObj
     name: string


### PR DESCRIPTION
The current Nim behavior is that the experimentals for call/dot operators only need to be enabled at the declaration site, and modules using the operators do not need it enabled. This behavior is changed in https://github.com/nim-lang/Nim/pull/16924. This example does not enable the callOperator experimental switch, making Nim's package CI break for that PR. Adding this switch here does not break the example for previous behavior.